### PR TITLE
Refactor/schedules

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,3 +3,4 @@ schedule==1.2.2
 python-dotenv==1.1.1
 PyNaCl==1.5.0
 pytz==2025.2
+ntplib==0.4.0

--- a/src/utils/ntp_client.py
+++ b/src/utils/ntp_client.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+import logging
+from datetime import datetime, timezone, timedelta
+import sys
+
+import ntplib
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+NTP_HOST = 'pool.ntp.org'
+TIME_ZONE = timezone(timedelta(hours=+9))
+
+class NTPRetrieve:
+    def __init__(self):
+        self.ntp_client = ntplib.NTPClient()
+        self.ntp_host = NTP_HOST
+        self.time_zone = TIME_ZONE
+
+    def get_locale_time(self):
+        try:
+            # version type rfc2030 and rfc4330
+            response = self.ntp_client.request(self.ntp_host, version=4)
+            unix_time = response.tx_time
+            dt_object = datetime.fromtimestamp(unix_time, timezone.utc)
+            # 指定されたtimezoneの時刻オブジェクトに変更
+            selected_time_zone = dt_object.astimezone(self.time_zone)
+            return selected_time_zone
+        except Exception:
+            logger.exception("NTPサーバーからの時刻取得に失敗しました。")
+            sys.exit(1)
+
+def main():
+    client = NTPRetrieve()
+    print(client.get_locale_time())
+
+if __name__ == "__main__":
+    main()

--- a/src/utils/schedules.py
+++ b/src/utils/schedules.py
@@ -79,4 +79,7 @@ def register_jobs(bot, join_time, start_time, end_time):
     all_jobs = schedule.get_jobs()
     all_jobs.sort(key=lambda x: x.next_run)
     for job in all_jobs:
-        logger.info(f"次の実行時間: {job.next_run} 実行間隔: {job.interval} 実行関数: {job.job_func.__name__}")
+        if job.job_func.__name__ == 'vc_join_or_leave':
+            logger.info(f"インターバル: {job.interval}分 実行関数: {job.job_func.__name__}")
+            continue
+        logger.info(f"設定時刻: {job.next_run.time()} 実行関数: {job.job_func.__name__}")


### PR DESCRIPTION
土曜日にも動作してしまっていた原因は以下のコードだと考えられます。
https://github.com/itstudy-jp/vw-bot/blob/d8626192f83b06654df2bd45c14387711a335dd0/src/utils/jobs.py#L21
https://github.com/itstudy-jp/vw-bot/blob/d8626192f83b06654df2bd45c14387711a335dd0/src/utils/jobs.py#L32
https://github.com/itstudy-jp/vw-bot/blob/d8626192f83b06654df2bd45c14387711a335dd0/src/utils/jobs.py#L40

`DT = datetime.now(JST)` は実行時の一度しか評価されていなかったので、実行日が平日であった場合には必ずTrueになり、その逆は必ずFalseになってしまっていました。

その修正と、NTPサーバーから時刻を取得してローカル時刻と併記したログの表示。
また、デバッグログを登録スケジュールではなく実行スケジュール(推論)を出力するように変更しました。